### PR TITLE
Misc fixes/updates:

### DIFF
--- a/server.js
+++ b/server.js
@@ -2,113 +2,134 @@ net = require('net');
 appInsights = require("applicationinsights");
 var client = appInsights.getClient();
 
-var sockets = [];
 var clientCounter = 1;
-var socketToId = {};
 var generalRoom = "GENERAL";
+var peers = {};
 
 var port = process.env.PORT || 8889;
 
 net.createServer(function (socket) {
 
-    socket.on('data', function (data) {
-        filterSockets();
+    socket.on('end', function() {
+        // Remove if wait socket
+        if(socket.waitPeer) {
+            socket.waitPeer.waitSocket = null;
+        }
+    });
 
-        data = "" + data;
+    socket.tmpData = "";
+
+    socket.on('data', function (newData) {
+        socket.tmpData  = socket.tmpData + newData;
+        var data = socket.tmpData;
         log(data);
 
         if (data.indexOf("sign_in") != -1) {
-            socket.id = clientCounter++;
-            socket.room = generalRoom;
-            socketToId[socket.id] = { name: data.substring(data.indexOf("?") + 1, data.indexOf("HTTP") - 1) };
+            var newPeer = {}
+            newPeer.id = clientCounter++;
+            newPeer.peerType = 'client';
+            newPeer.messages = [];
+            newPeer.name = data.substring(data.indexOf("?") + 1, data.indexOf("HTTP") - 1)
             if (data.indexOf("renderingclient_") != -1) {
-                socketToId[socket.id].isRenderingClient = true;
-                socket.isRenderingClient = true;
+                newPeer.peerType = 'client';
             }
             if (data.indexOf("renderingserver_") != -1) {
-                socketToId[socket.id].isRenderingServer = true;
-                socket.isRenderingServer = true;
+                newPeer.peerType = 'server';
             }
-            socket.write(formatMessage("200 Added", formatListOfClients(socket, true), socket.id, true));
-            notifyOtherSockets(socket);
+            peers[newPeer.id] = newPeer;
+            socket.write(formatMessage("200 Added", formatListOfPeers(newPeer), newPeer.id));
+            notifyOtherPeers(newPeer);
+            socket.tmpData = "";
         }
         else if (data.indexOf("wait") != -1) {
-            socket.room = generalRoom;
-            socket.id = data.substring(data.indexOf("peer_id=") + 8, data.indexOf("HTTP") - 1);
+            var peerId = data.substring(data.indexOf("peer_id=") + 8, data.indexOf("HTTP") - 1);
+            socket.waitPeer = peers[peerId];
+            peers[peerId].waitSocket = socket;
+            sendMessageToPeer(peers[peerId], null, null);
         }
-
         else if (data.indexOf("message") != -1) {
             var fromId = data.substring(data.indexOf("peer_id=") + 8, data.indexOf("&to"));
             var toId = data.substring(data.indexOf("&to") + 4, data.indexOf("HTTP") - 1);
-            var toSocket = getSocketById(toId);
-            var payload = data.substring(data.indexOf("text/plain\r\n\r\n") + 14, data.length);
-            socket.id = fromId;
-            socket.room = fromId + "_" + toId;
-            toSocket.room = socket.room;
-            forwardMessageToPeer(socket, toSocket, payload);
+            var payload = data.substring(data.indexOf("\r\n\r\n") + 4, data.length);
+            var contentLength = /[cC]ontent-[lL]ength: (\d+)/.exec(data)[1]
+            contentLength = parseInt(contentLength);
+            if(contentLength <= payload.length) {
+                peers[toId].roomPeer = peers[fromId]
+                peers[fromId].roomPeer = peers[toId];
+                sendMessageToPeer(peers[toId], payload, fromId);
+                socket.write(formatMessage("200 OK", "", fromId));
+                socket.tmpData = "";
+            }
         }
+        else if (data.indexOf("sign_out") != -1) {
+            var peerId = data.substring(data.indexOf("peer_id=") + 8, data.indexOf("HTTP") - 1);
+            var peer = peers[peerId]
+            delete peers[peerId]
 
-        sockets.push(socket);
-        log("Total open sockets " + sockets.length);
-
+            if(peer.roomPeer) {
+                peer.roomPeer.roomPeer = null;
+                peer.roomPeer = null;
+            }
+            socket.write(formatMessage("200 OK", "", peerId));
+            socket.tmpData = "";
+        }
     });
 
     socket.on('error', function (e) {
         log("Error", e);
     });
 
-    function filterSockets() {
-        sockets = sockets.filter(function (value) {
-            return !value.destroyed;
-        })
-    }
-
-    function forwardMessageToPeer(currentSocket, toSocket, data) {
-        toSocket.write(formatMessage("200 OK", data, currentSocket.id, false));
-        currentSocket.write(formatMessage("200 OK", "", currentSocket.id, true));
-    }
-
-    function notifyOtherSockets(currentSocket) {
-        sockets.forEach(function (socket) {
-            if (socket.id === currentSocket.id ||
-                socket.room != currentSocket.room ||
-                (currentSocket.isRenderingClient && socketToId[socket.id].isRenderingClient) ||
-                (currentSocket.isRenderingServer && socketToId[socket.id].isRenderingServer))
-                return;
-            var data = socketToId[currentSocket.id].name + "," + currentSocket.id + ",1\n";
-            var message = formatMessage("200 OK", data, socket.id, true);
-            socket.write(message);
-        });
-    }
-
-    function getSocketById(id) {
-        return sockets.find(socket => {
-            if (socket.id === id) return socket;
-        });
-    }
-
-    function formatListOfClients(currentSocket) {
-
-        var result = socketToId[currentSocket.id].name + "," + currentSocket.id + ",1\n";
-        sockets.forEach(function (socket) {
-            if (socket.id != currentSocket.id &&
-                socketToId[socket.id] &&
-                socket.room == currentSocket.room &&
-                !(currentSocket.isRenderingClient && socketToId[socket.id].isRenderingClient) &&
-                !(currentSocket.isRenderingServer && socketToId[socket.id].isRenderingServer)) {
-                result += socketToId[socket.id].name + "," + socket.id + ",1\n"
+    function sendMessageToPeer(peer, payload, fromId) {
+        var msg  = {};
+        if(payload) {
+            msg.id = fromId || peer.id;
+            msg.payload = payload;
+            peer.messages.push(msg);
+        }
+        if(peer.waitSocket) {
+            msg = peer.messages.shift();
+            if(msg) {
+                peer.waitSocket.write(formatMessage("200 OK", msg.payload, msg.id));
+                peer.waitSocket.waitPeer = null;
+                peer.waitSocket.tmpData = "";
+                peer.waitSocket = null;
             }
-        });
-        console.log(result);
+        }
+    }
 
+    function isPeerCandidate(peer, otherPeer) {
+        return (otherPeer.id != peer.id && // filter self
+                !otherPeer.roomPeer && // filter peers in 'rooms'
+                otherPeer.peerType != peer.peerType) // filter out peers of same type
+    }
+
+    function notifyOtherPeers(newPeer) {
+        for(peerId in peers) {
+            var otherPeer = peers[peerId];
+            if (isPeerCandidate(newPeer, otherPeer)) {
+                var data = newPeer.name + "," + newPeer.id + ",1\n";
+                sendMessageToPeer(otherPeer, data);
+            }
+        }
+    }
+
+    function formatListOfPeers(peer) {
+        var result = peer.name + "," + peer.id + ",1\n";
+        for(peerId in peers) {
+            var otherPeer = peers[peerId];
+            if (isPeerCandidate(peer, otherPeer)) {
+                result += otherPeer.name + "," + otherPeer.id + ",1\n"
+            }
+        }
+        console.log(result);
         return result;
     }
 
-    function formatMessage(status, data, pragma, shouldCloseConnection) {
+    function formatMessage(status, data, pragma) {
         var message = "HTTP/1.1 " + status + " \r\n" +
             "Server: PeerConnectionTestServer/0.1\r\n" +
             "Cache-Control: no-cache\r\n" +
-            (shouldCloseConnection ? "Connection: close\r\n" : "") +
+            "Connection: close\r\n" +
             "Content-Type: text/plain\r\n" +
             "Content-Length: " + data.length + "\r\n" +
             "Pragma: " + pragma + "\r\n" +


### PR DESCRIPTION
- All responses set `Connection: close` header
- Sent messages are sent if there is a pending wait call for the
  receiver or queued otherwise
- Wait calls return one item now (i.e. use close behavior mentioned
  above)
- Handle Message requests that are split
    - Large enough requests come across on mulitple 'data' events
    - Build up a buffer until request is equal or larger than content length



**NOTE**: There is little error handling here so any bad or non-compliant client can probably crash the server easily!